### PR TITLE
修复*.py文件默认使用vscode打开的问题

### DIFF
--- a/client/win_device_autostart.vbs
+++ b/client/win_device_autostart.vbs
@@ -1,2 +1,2 @@
 Set ws = CreateObject("Wscript.Shell")
-ws.run "cmd /c %UserProfile%\win_device.py",vbhide
+ws.run "cmd /c python %UserProfile%\win_device.py",vbhide


### PR DESCRIPTION
直接用cmd启动的话，py文件和vscode绑定会自动使用vscode打开