### PR TITLE
提供兼容非 FHS 发行版的 Hyprland 客户端 && 动态获取脚本根目录

### DIFF
--- a/client/linux_device_hyprland.sh
+++ b/client/linux_device_hyprland.sh
@@ -15,7 +15,9 @@ LASTWINDOW="inoryxin" # 这个变量是让电脑第一次开机进桌面不进�
 
 while true; do
 
-    PACKAGE_NAME=$(/usr/bin/hyprctl activewindow | grep "title:" | sed 's/title://g' | sed 's/^[[:space:]]*//')
+    HYPRCTL_BIN=$(which hyprctl)
+
+    PACKAGE_NAME=$($HYPRCTL_BIN activewindow | grep "title:" | sed 's/title://g' | sed 's/^[[:space:]]*//')
 
     echo "$PACKAGE_NAME"
 

--- a/data.py
+++ b/data.py
@@ -22,14 +22,14 @@ class data:
     data_check_interval: int = 60
 
     def __init__(self):
-        with open('data.template.json', 'r', encoding='utf-8') as file:
+        with open(os.path.join(u.current_dir(), 'data.template.json'), 'r', encoding='utf-8') as file:
             self.preload_data = json.load(file)
-        if os.path.exists('data.json'):
+        if os.path.exists(os.path.join(u.current_dir(), 'data.json')):
             try:
                 self.load()
             except Exception as e:
                 u.warning(f'Error when loading data: {e}, try re-create')
-                os.remove('data.json')
+                os.remove(os.path.join(u.current_dir(), 'data.json'))
                 self.data = self.preload_data
                 self.save()
                 self.load()
@@ -56,11 +56,11 @@ class data:
 
         while attempts > 0:
             try:
-                if not os.path.exists('data.json'):
+                if not os.path.exists(os.path.join(u.current_dir(), 'data.json')):
                     u.warning('data.json not exist, try re-create')
                     self.data = self.preload_data
                     self.save()
-                with open('data.json', 'r', encoding='utf-8') as file:
+                with open(os.path.join(u.current_dir(), 'data.json'), 'r', encoding='utf-8') as file:
                     Data = json.load(file)
                     DATA: dict = {**preload, **Data}
                     if ret:
@@ -81,7 +81,7 @@ class data:
         保存配置
         '''
         try:
-            with open('data.json', 'w', encoding='utf-8') as file:
+            with open(os.path.join(u.current_dir(), 'data.json'), 'w', encoding='utf-8') as file:
                 json.dump(self.data, file, indent=4, ensure_ascii=False)
         except Exception as e:
             u.error(f'Failed to save data.json: {e}')

--- a/env.py
+++ b/env.py
@@ -2,7 +2,7 @@
 import os
 import utils as u
 from dotenv import load_dotenv, find_dotenv
-dotenv_filename = '.env'
+dotenv_filename = os.path.join(u.current_dir(), ".env")
 if not find_dotenv(filename=dotenv_filename):
     u.warning("未找到 .env 文件，将使用默认配置，部分功能可能失效！")
 load_dotenv(dotenv_path=dotenv_filename)

--- a/setting.py
+++ b/setting.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 
+from os.path import join
+
 import json
 import utils as u
-
 
 class setting:
     '''
@@ -24,6 +25,5 @@ class setting:
         except Exception as e:
             u.exception(f'[setting] Error loading {filename}: {e}')
 
-
-status_list: list = setting('setting/status_list.json').content
-metrics_list: list = setting('setting/metrics_list.json').content
+status_list: list = setting(join(u.current_dir(),'setting/status_list.json')).content
+metrics_list: list = setting(join(u.current_dir() ,'setting/metrics_list.json')).content

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import json
 from flask import make_response, Response
+from pathlib import Path
 
 
 def info(log):
@@ -113,3 +114,7 @@ def exception(msg: str):
     :param msg: 错误描述
     '''
     raise SleepyException(msg)
+
+
+def current_dir():
+    return Path(__file__).parent


### PR DESCRIPTION
## 对于 https://github.com/wyf9/sleepy/pull/60/commits/03069bc1e894d116a2934cad70d2a2c6b3c26f1c

 - 在 Linux 上使用 systemd 直接运行该服务端时，由于错误的相对路径引用，脚本无法正常工作，因此添加该 workaround ，后期应考虑一种更通用化的实现方法

## 对于  https://github.com/wyf9/sleepy/commit/ae9faf221063204d5aa25588795d04a7bd2addc4

 - 像 NixOS 这种非 FHS 发行版，硬编码 `/usr/bin/hyprctl` 会导致脚本无法运行
 - 此外，对于 NixOS ，应使用 Home Manager + Systemd user unit 实现开机自动上报和关机事件监听，我已经实现了一个可以用的版本，但是现在太晚了，如果有需要我明天可以再开一个 pr。我先把大概的实现贴在这里

```nix
{
  systemd.user.services.status-report = {
    Unit.Description = "Status report task";
    Unit.After = [ "network-online.target" "graphical-session.target" ];
    Unit.Before = [ "shutdown.target" "reboot.target" "halt.target" ];

    Service = {
      Type = "simple";
      ExecStart = "${pkgs.writeShellScript "my-startup-script" ''
        # 基本同开机脚本内容
      ''} ";
      ExecStop = "${pkgs.writeShellScript "my-shutdown-script" ''
        #!/bin/bash
        # --- config start 这里借用 linux_device_hyprland.sh 的内容，感谢作者
        URL="" # API 地址, 以 /device/set 结尾
        SECRET="" # 密钥
        DEVICE_ID="" # 设备 id, 唯一
        DEVICE_SHOW_NAME="" # 设备显示名称
        # --- config end

        json_data='{
          "secret": "'$SECRET'",
          "id": "'$DEVICE_ID'",
          "show_name": "'$DEVICE_SHOW_NAME'",
          "using": "false",
          "app_name": "Client shutdown"
        }'

        curl -X POST "$URL" -H "Content-Type: application/json" -d "$json_data"
      ''} ";
      Restart = "on-failure";
      RestartSec = 5;
    };

    Install.WantedBy = [ "graphical-session.target" ];
  };
}

```